### PR TITLE
Add saving and updating passwords to Apple Passwords

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -80,11 +80,23 @@ function registrableHost(u) {
   }
 }
 
+// loopback (secure context) and reserved .test / .localhost TLDs (RFC 6761, never real
+// sites) are the only non-HTTPS origins we treat as fillable/saveable
+function isLocalDevHost(host) {
+  return (
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host === "[::1]" ||
+    host?.endsWith(".localhost") ||
+    host?.endsWith(".test")
+  );
+}
+
 // messages a content script may send. operate only on the sender's own tab/origin
 // and never return a password to the page (inlineFill pushes straight to the fill
 // handler, page script never sees it). verifyPin takes a PIN guess and returns lock
 // state only, never vault data
-const CONTENT_ALLOWED = new Set(["inlineLogins", "inlineFill", "requestChallenge", "verifyPin"]);
+const CONTENT_ALLOWED = new Set(["inlineLogins", "inlineFill", "requestChallenge", "verifyPin", "maybeSave"]);
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   (async () => {
@@ -155,6 +167,28 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
           sendResponse({ ok: true, filled });
           break;
         }
+
+        case "maybeSave": {
+          // a content script offering credentials the user just submitted. the native
+          // macOS prompt is the real gate (nothing is written to the vault without the
+          // user confirming there), so we only forward. pin to the sender frame's own
+          // origin, never the top tab's
+          const frameUrl = sender.url;
+          if (!frameUrl || sender.tab?.id == null) {
+            return sendResponse({ ok: false, error: "no frame" });
+          }
+          const host = registrableHost(frameUrl);
+          if (!/^https:\/\//i.test(frameUrl) && !isLocalDevHost(host)) {
+            return sendResponse({ ok: false, error: "refusing to save from a non-HTTPS frame" });
+          }
+          if (!msg.password) return sendResponse({ ok: false, error: "no password" });
+          await ensureConnected();
+          if (!client.ready) return sendResponse({ ok: true, saved: false, locked: true });
+          await client.saveLogin(sender.tab.id, frameUrl, msg.username ?? "", msg.password);
+          sendResponse({ ok: true, saved: true });
+          break;
+        }
+
         case "getState":
           await ensureConnected();
           sendResponse({ ok: true, state: client.state });

--- a/src/content.js
+++ b/src/content.js
@@ -279,7 +279,7 @@ function buildSuggestionBox(field) {
 
 // locked: PIN field in the dropdown so the user can unlock without leaving the page.
 // background issues a challenge (macos shows the 6-digit code), then verify inline
-async function buildLockedSuggestion(field) {
+async function buildLockedSuggestion(field, onUnlock) {
   const box = buildSuggestionBox(field);
 
   const msg = document.createElement("div");
@@ -341,6 +341,12 @@ async function buildLockedSuggestion(field) {
     }
     verifying = false;
     if (res?.ok && res.state === "unlocked") {
+      // caller wants to resume its own action after unlock (e.g. save the password)
+      if (typeof onUnlock === "function") {
+        removeSuggestion();
+        onUnlock();
+        return;
+      }
       // unlocked: complete the autofill they already asked for - fill directly on a
       // single match, else show the chooser
       cachedLogins = null;
@@ -498,6 +504,118 @@ document.addEventListener(
     // closing now (mousedown before focusin) would race and leave it with no dropdown
     if (e.target instanceof HTMLInputElement && isLoginField(e.target)) return;
     removeSuggestion();
+  },
+  true,
+);
+
+// --- save / update -------------------------------------------------------------
+// offer to store credentials the user submits, like chrome/safari "save password?".
+// we forward the submitted username+password to the helper, which decides add-vs-update
+// and shows the native macOS prompt - nothing is written without the user confirming
+// there. fires only on genuine (isTrusted) user submits
+let lastSaveKey = "";
+let lastSaveAt = 0;
+
+// treat a control as a submit if it is type=submit, or a button whose label reads like
+// a sign-in / sign-up / save action (covers SPA logins with no real <form> submit)
+const SUBMITY_LABEL =
+  /\b(sign[\s-]?in|sign[\s-]?up|log[\s-]?in|register|create[\s-]?account|save|update|change[\s-]?password|continue|next|submit)\b/i;
+
+function isSubmitControl(el) {
+  if (!(el instanceof Element)) return false;
+  const tag = el.tagName.toLowerCase();
+  const type = (el.getAttribute("type") || "").toLowerCase();
+  if ((tag === "button" || tag === "input") && type === "submit") return true;
+  if (tag === "button" && (type === "" || type === "button")) {
+    return SUBMITY_LABEL.test((el.textContent || el.value || attrBlob(el)) ?? "");
+  }
+  return false;
+}
+
+// pick the credential the user submitted within a scope. the "new" password on a
+// change/confirm form is the last password field with a value; the username is the
+// login field just before the first password
+function collectSubmittedCredentials(scope) {
+  const root = scope && scope.querySelectorAll ? scope : document;
+  const inputs = Array.from(root.querySelectorAll("input"));
+  const pws = inputs.filter((i) => isPasswordField(i) && i.value);
+  if (!pws.length) return null;
+  const password = pws[pws.length - 1].value;
+  const firstPw = pws[0];
+  const users = inputs.filter((i) => isUsernameField(i) && i.value);
+  let username = "";
+  if (users.length) {
+    const before = users.filter(
+      (u) => u.compareDocumentPosition(firstPw) & Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    username = (before.length ? before[before.length - 1] : users[0]).value;
+  }
+  return { username: username.trim(), password };
+}
+
+async function maybeOfferSave(scope) {
+  if (!frameIsSafe()) return;
+  const cred = collectSubmittedCredentials(scope);
+  if (!cred || !cred.password) return;
+  // a submit often fires both a click and a submit event - dedupe identical creds
+  const key = `${location.hostname} ${cred.username} ${cred.password}`;
+  const now = Date.now();
+  if (key === lastSaveKey && now - lastSaveAt < 5000) return;
+  lastSaveKey = key;
+  lastSaveAt = now;
+
+  let res;
+  try {
+    res = await chrome.runtime.sendMessage({
+      type: "maybeSave",
+      username: cred.username,
+      password: cred.password,
+    });
+  } catch {
+    return;
+  }
+  if (res?.ok && res.locked) {
+    // locked at submit time: let the user unlock inline, then save. anchor on the
+    // password field theyre using so the box appears in a sensible spot
+    const field =
+      document.activeElement instanceof HTMLInputElement && isPasswordField(document.activeElement)
+        ? document.activeElement
+        : Array.from(document.querySelectorAll('input[type="password"]')).find(isVisible);
+    if (field) {
+      buildLockedSuggestion(field, () =>
+        chrome.runtime
+          .sendMessage({ type: "maybeSave", username: cred.username, password: cred.password })
+          .catch(() => {}),
+      );
+    }
+  }
+}
+
+document.addEventListener(
+  "submit",
+  (e) => {
+    if (e.isTrusted) maybeOfferSave(e.target);
+  },
+  true,
+);
+document.addEventListener(
+  "click",
+  (e) => {
+    if (!e.isTrusted || !(e.target instanceof Element)) return;
+    const ctrl = e.target.closest("button, input[type=submit], input[type=button]");
+    if (isSubmitControl(ctrl)) maybeOfferSave(ctrl.form || document);
+  },
+  true,
+);
+// Enter inside a login field on a formless (SPA) login
+document.addEventListener(
+  "keydown",
+  (e) => {
+    if (!e.isTrusted || e.key !== "Enter") return;
+    const t = e.target;
+    if (t instanceof HTMLInputElement && (isPasswordField(t) || isUsernameField(t))) {
+      maybeOfferSave(t.form || document);
+    }
   },
   true,
 );

--- a/src/protocol.js
+++ b/src/protocol.js
@@ -25,13 +25,14 @@ export const Command = {
   HANDSHAKE: 2,
   GET_LOGIN_NAMES_FOR_URL: 4,
   GET_PASSWORD_FOR_LOGIN_NAME: 5,
+  SET_PASSWORD_FOR_LOGIN_NAME_URL: 6, // save or update a login
   TAB_EVENT: 8,
   PASSWORDS_DISABLED: 9,
   RELOGIN_NEEDED: 10,
   GET_CAPABILITIES: 14,
 };
 
-const Action = { SEARCH: 2, GHOST_SEARCH: 5 };
+const Action = { UPDATE: 1, SEARCH: 2, ADD_NEW: 3, MAYBE_ADD: 4, GHOST_SEARCH: 5 };
 
 export const State = {
   Disconnected: "disconnected",
@@ -301,6 +302,45 @@ export class ApplePasswords {
       }
       if (res.STATUS === QueryStatus.NoResults) return undefined;
       throw queryStatusError(res.STATUS);
+    });
+  }
+
+  // save or update a login in Apple Passwords. cmd 6 with ACT maybeAdd lets the helper
+  // decide add-vs-update and drive the native macOS save prompt (with Touch ID). the
+  // helper's cmd-6 reply carries no decryptable body so we dont parse one - a page can
+  // only ever trigger the OS prompt, never write to the vault silently
+  async saveLogin(tabId, url, username, password) {
+    if (!this.ready) throw new Error("not unlocked");
+    if (!password) throw new Error("no password to save");
+    const { hostname } = new URL(url);
+    return this._withLock(async () => {
+      const sdata = this.session.serialize(
+        await this.session.encrypt({
+          ACT: Action.MAYBE_ADD,
+          URL: "",
+          USR: "",
+          PWD: "",
+          NURL: hostname,
+          NUSR: username ?? "",
+          NPWD: password,
+        }),
+      );
+      const body = {
+        tabId,
+        frameId: 0,
+        payload: {
+          QID: "CmdNewAccount4URL",
+          SMSG: JSON.stringify({ TID: this.session.username, SDATA: sdata }),
+        },
+      };
+      // the ack is empty and user confirmation happens in the native prompt, so a
+      // missing or slow ack is not an error
+      try {
+        await this._send(Command.SET_PASSWORD_FOR_LOGIN_NAME_URL, body, 3000);
+      } catch (e) {
+        if (!/timeout/i.test(String(e?.message ?? e))) throw e;
+      }
+      return true;
     });
   }
 


### PR DESCRIPTION
## What & why

Right now the extension is **read-only** — it fills saved logins but can't create or update them, so every new signup and password change has to be saved by hand in the Passwords app. This PR adds **save / update** support so it works as a full password manager.

## How it works

Apple's native helper exposes this through command **6 (`SetPassword4LoginName_URL`)** with action **`maybeAdd`**. That action lets the helper decide add-vs-update on its own and show its **native macOS prompt** (with Touch ID). The reply carries no decryptable body, so nothing is parsed back — the extension only ever *triggers* the OS prompt, it never writes to the vault directly.

- **`protocol.js`** — `ApplePasswords.saveLogin()` sends the encrypted `{ACT: maybeAdd, NURL, NUSR, NPWD}` payload over command 6. The `{TID, SDATA}` wrapper is the same one the existing read path uses, so it reuses all the SRP/AES plumbing.
- **`background.js`** — a new `maybeSave` broker message (added to `CONTENT_ALLOWED`), HTTPS/local-dev gated and pinned to the sender frame's own origin. Returns `{locked: true}` when the session isn't unlocked.
- **`content.js`** — detects genuine (`isTrusted`) credential submits — form `submit`, submit-like button click, and Enter in a login field — picks the submitted username/password, and forwards them. `buildLockedSuggestion` gains an optional `onUnlock` callback so a submit made while the extension is locked can unlock inline and then complete the save.

## Security model

Nothing is stored silently. The content script can only *trigger* the native macOS prompt; the OS requires the user to confirm (Touch ID / click) before anything is written. Same origin-pinning and HTTPS gating as the existing fill path. Because `maybeAdd` de-dupes, the prompt only appears when a credential is genuinely **new or changed** — logging into an already-saved site stays silent.

## Behaviour

| Action | Result |
| --- | --- |
| New signup | native "Save Password?" prompt |
| Password change | native "Update Password?" prompt |
| Log into a site you'd typed manually before | offers to save it |
| Log into an already-saved site, same password | silent (no prompt) |

## Testing

Tested on macOS with the Passwords app: new signups and password changes both produce the native save/update prompt, and existing-credential logins stay silent. No changes to the read/fill paths, icons, or manifest — the diff is scoped to the three source files.

*Command/action mapping was derived from the official iCloud Passwords extension's behaviour; the `{TID, SDATA}` encryption path is unchanged from this repo's existing read implementation.*
